### PR TITLE
Support for circles that cover the poles

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -1,6 +1,7 @@
-;(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 var spherical = require('spherical'),
-    geojsonArea = require('geojson-area');
+    geojsonArea = require('geojson-area'),
+    wgs84 = require('wgs84');
 
 module.exports.circle = function(center, radius, opt) {
     center = L.latLng(center);
@@ -14,6 +15,24 @@ module.exports.circle = function(center, radius, opt) {
                 [center.lng, center.lat],
                 (i / parts) * 360, radius).reverse());
         }
+
+        var angularRadius = radius / wgs84.RADIUS * 180 / Math.PI;
+
+        if ( angularRadius > (90 - center.lat) ) {
+            lls.push([ lls[0][0], center.lng+180 ],
+                [ 90, center.lng+180 ],
+                [ 90, center.lng-180 ],
+                [ lls[0][0], center.lng-180 ]);
+        }
+
+        if ( angularRadius > (90 + center.lat) ) {
+            lls.splice( (parts>>1)+1, 0,
+                [ lls[ (parts>>1) ][0], center.lng-180 ],
+                [ -90, center.lng-180 ],
+                [ -90, center.lng+180 ],
+                [ lls[ (parts>>1) ][0], center.lng+180 ] );
+        }
+
         return lls;
     }
 
@@ -43,7 +62,7 @@ module.exports.area = function(layer) {
     return geojsonArea(gj.geometry);
 };
 
-},{"geojson-area":2,"spherical":4}],2:[function(require,module,exports){
+},{"geojson-area":2,"spherical":4,"wgs84":6}],2:[function(require,module,exports){
 var wgs84 = require('wgs84');
 
 module.exports = function(_) {
@@ -172,6 +191,8 @@ function deg(_) {
 },{"wgs84":5}],5:[function(require,module,exports){
 module.exports=require(3)
 },{}],6:[function(require,module,exports){
+module.exports=require(3)
+},{}],7:[function(require,module,exports){
 var desy = require('./');
 
 var map = L.mapbox.map('map', 'examples.map-i86knfo3')
@@ -205,5 +226,4 @@ r.onload = load;
 r.open("get", "data/states.geojson", true);
 r.send();
 
-},{"./":1}]},{},[6])
-;
+},{"./":1}]},{},[7])

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var spherical = require('spherical'),
-    geojsonArea = require('geojson-area');
+    geojsonArea = require('geojson-area'),
+    wgs84 = require('wgs84');
 
 module.exports.circle = function(center, radius, opt) {
     center = L.latLng(center);
@@ -13,6 +14,24 @@ module.exports.circle = function(center, radius, opt) {
                 [center.lng, center.lat],
                 (i / parts) * 360, radius).reverse());
         }
+
+        var angularRadius = radius / wgs84.RADIUS * 180 / Math.PI;
+
+        if ( angularRadius > (90 - center.lat) ) {
+            lls.push([ lls[0][0], center.lng+180 ],
+                [ 90, center.lng+180 ],
+                [ 90, center.lng-180 ],
+                [ lls[0][0], center.lng-180 ]);
+        }
+
+        if ( angularRadius > (90 + center.lat) ) {
+            lls.splice( (parts>>1)+1, 0,
+                [ lls[ (parts>>1) ][0], center.lng-180 ],
+                [ -90, center.lng-180 ],
+                [ -90, center.lng+180 ],
+                [ lls[ (parts>>1) ][0], center.lng+180 ] );
+        }
+
         return lls;
     }
 

--- a/leaflet-geodesy.js
+++ b/leaflet-geodesy.js
@@ -1,6 +1,7 @@
-!function(e){"object"==typeof exports?module.exports=e():"function"==typeof define&&define.amd?define(e):"undefined"!=typeof window?window.LGeo=e():"undefined"!=typeof global?global.LGeo=e():"undefined"!=typeof self&&(self.LGeo=e())}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-var spherical = require('spherical'),
-    geojsonArea = require('geojson-area');
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.LGeo=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+var spherical = _dereq_('spherical'),
+    geojsonArea = _dereq_('geojson-area'),
+    wgs84 = _dereq_('wgs84');
 
 module.exports.circle = function(center, radius, opt) {
     center = L.latLng(center);
@@ -14,6 +15,24 @@ module.exports.circle = function(center, radius, opt) {
                 [center.lng, center.lat],
                 (i / parts) * 360, radius).reverse());
         }
+
+        var angularRadius = radius / wgs84.RADIUS * 180 / Math.PI;
+
+        if ( angularRadius > (90 - center.lat) ) {
+            lls.push([ lls[0][0], center.lng+180 ],
+                [ 90, center.lng+180 ],
+                [ 90, center.lng-180 ],
+                [ lls[0][0], center.lng-180 ]);
+        }
+
+        if ( angularRadius > (90 + center.lat) ) {
+            lls.splice( (parts>>1)+1, 0,
+                [ lls[ (parts>>1) ][0], center.lng-180 ],
+                [ -90, center.lng-180 ],
+                [ -90, center.lng+180 ],
+                [ lls[ (parts>>1) ][0], center.lng+180 ] );
+        }
+
         return lls;
     }
 
@@ -43,8 +62,8 @@ module.exports.area = function(layer) {
     return geojsonArea(gj.geometry);
 };
 
-},{"geojson-area":2,"spherical":4}],2:[function(require,module,exports){
-var wgs84 = require('wgs84');
+},{"geojson-area":2,"spherical":4,"wgs84":6}],2:[function(_dereq_,module,exports){
+var wgs84 = _dereq_('wgs84');
 
 module.exports = function(_) {
     if (_.type === 'Polygon') return polygonArea(_.coordinates);
@@ -105,13 +124,13 @@ function rad(_) {
     return _ * Math.PI / 180;
 }
 
-},{"wgs84":3}],3:[function(require,module,exports){
+},{"wgs84":3}],3:[function(_dereq_,module,exports){
 module.exports.RADIUS = 6378137;
 module.exports.FLATTENING = 1/298.257223563;
 module.exports.POLAR_RADIUS = 6356752.3142;
 
-},{}],4:[function(require,module,exports){
-var wgs84 = require('wgs84');
+},{}],4:[function(_dereq_,module,exports){
+var wgs84 = _dereq_('wgs84');
 
 module.exports.heading = function(from, to) {
     var y = Math.sin(Math.PI * (from[0] - to[0]) / 180) * Math.cos(Math.PI * to[1] / 180);
@@ -169,9 +188,10 @@ function deg(_) {
     return _ * (180 / Math.PI);
 }
 
-},{"wgs84":5}],5:[function(require,module,exports){
-module.exports=require(3)
+},{"wgs84":5}],5:[function(_dereq_,module,exports){
+module.exports=_dereq_(3)
+},{}],6:[function(_dereq_,module,exports){
+module.exports=_dereq_(3)
 },{}]},{},[1])
 (1)
 });
-;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "geojson-area": "0.0.1",
-    "spherical": "0.1.0"
+    "spherical": "0.1.0",
+    "wgs84": "0.0.0"
   },
   "devDependencies": {
     "watchify": "~0.4.1",


### PR DESCRIPTION
Circles that cover the poles aren’t rendered correctly right now, as shown here:
![Incorrect Polygon](https://cloud.githubusercontent.com/assets/614874/3708000/e83da6fc-143c-11e4-9d3e-ac3c8201d3ff.png)

If the angular radius from the centre is bigger than the colatitude, the polygon should cover the area of pole down to the latitude of the southernmost point. The polygon is modified by inserting four points to ensure this.
Same method is applied when the south pole is covered by the circle.

![post](https://cloud.githubusercontent.com/assets/614874/3708006/f455f7fa-143c-11e4-92a3-3d4c5d8659f8.png)

The “width” is limited to 360 degrees so that the correct area of the polygon can be calculated.
Making the width bigger by adding/subtracting more than 180 would look nicer, but causes new errors (e.g. missing repetition of the “curved part”)
