### PR TITLE
Remove examples IDs

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -195,7 +195,7 @@ module.exports=require(3)
 },{}],7:[function(require,module,exports){
 var desy = require('./');
 
-var map = L.mapbox.map('map', 'examples.map-i875mjb7')
+var map = L.mapbox.map('map', 'mapbox.streets')
   .setView([0, 0], 2);
 
 var planarCircle = L.circle([0, 0], 2000000, {

--- a/site.js
+++ b/site.js
@@ -1,6 +1,6 @@
 var desy = require('./');
 
-var map = L.mapbox.map('map', 'examples.map-i875mjb7')
+var map = L.mapbox.map('map', 'mapbox.streets')
   .setView([0, 0], 2);
 
 var planarCircle = L.circle([0, 0], 2000000, {


### PR DESCRIPTION
Switches `examples` IDs for `mapbox.streets`. cc @tmcw 
