### PR TITLE
Create getCenter method

### DIFF
--- a/leaflet-geodesy.js
+++ b/leaflet-geodesy.js
@@ -53,6 +53,10 @@ module.exports.circle = function(center, radius, opt) {
         poly.setLatLngs(generate(center));
         return poly;
     };
+    
+    poly.getCenter = function(_) {
+        return center;
+    };
 
     return poly;
 };


### PR DESCRIPTION
I'm surprised no-one has needed it yet.
This only adds a method to get the Latlng which refers to the center of the geodesic circle.

IMPORTANT TO TEST:
what happens if the circle gets really close to the poles? (since the center will be in some weird spot)
is it accurate when circles start getting "warped"? (i don't fully know how center is defined so it might not be accurate)

for my purposes, this worked. I have not tested other scenario's.